### PR TITLE
Add value attribute to progress element

### DIFF
--- a/src/uix/elements/_progress.py
+++ b/src/uix/elements/_progress.py
@@ -6,6 +6,7 @@ class progress(Element):
         self.tag = "progress"
         self.max = max
         self.attrs["max"] = max
+        self.attrs["value"] = value
 
 
 


### PR DESCRIPTION
progress value değeri progress bar'ın ilerlemesini değiştirmek yerine tag olarak gözüküyordu. @hozgur @ncfex 